### PR TITLE
Jenkins npm proxy cache

### DIFF
--- a/jenkins/ec2_bootstrap.sh
+++ b/jenkins/ec2_bootstrap.sh
@@ -381,6 +381,17 @@ install_ruby() {
   su -l ubuntu -c bash -c "curl -sSL https://get.rvm.io | bash -s stable --ruby"
 }
 
+# Use nodesource repos to install NodeJS & sinopia.
+install_npm_proxy_cache() {
+  # Ugh - but this is the way we install Node elsewhere.
+  curl -sL https://deb.nodesource.com/setup_4.x | bash -
+  apt-get install -y nodejs
+  # Install sinopia globally and set up a boot-time service
+  npm install -g forever forever-service sinopia
+  mkdir -p /mnt/sinopia
+  forever-service install --start --script /usr/bin/sinopia -f ' --workingDir /mnt/' sinopia
+}
+
 install_docker() {
   # Add the repository to your APT sources
   echo deb https://apt.dockerproject.org/repo ubuntu-precise main > /etc/apt/sources.list.d/docker.list
@@ -499,6 +510,7 @@ function main() {
     install_ruby
     install_docker
     install_datadog_agent
+    install_npm_proxy_cache
     if [[ -n "$PREPARE_COWBUILDER" ]]; then prepare_cowbuilder; fi
 }
 


### PR DESCRIPTION
Install & start a slave-local npm proxy cache. This should help with npm reliability issues, and improve performance of npm install.

Please review @ashanbrown 