### PR TITLE
remove DD Jenkins from slaves as they don't have the necessary Job fi…

### DIFF
--- a/jenkins/ec2_bootstrap.sh
+++ b/jenkins/ec2_bootstrap.sh
@@ -467,10 +467,6 @@ class { '::datadog_agent':
   tags => ['devtools_group:ci', 'devtools_ci:jenkins'],
 } ->
 
-class { '::datadog_agent::integrations::jenkins':
-  path => '${JENKINS_HOME}',
-}
-
 service { 'puppet':
   ensure => stopped,
   enable => false,


### PR DESCRIPTION
…les.

This is will put an end to the DD agent log messages which are filling up /var/log.

@ashanbrown @niallo 