### PR TITLE
Bind datadog to 0.0.0.0 instead of 127.0.0.1

### DIFF
--- a/jenkins/ec2_bootstrap.sh
+++ b/jenkins/ec2_bootstrap.sh
@@ -480,6 +480,7 @@ install_datadog_agent() {
 
 class { '::datadog_agent': 
   api_key => '${DATADOG_AGENT_API_KEY}',
+  bind_host => '0.0.0.0',
   log_level => 'error',
   tags => ['devtools_group:ci', 'devtools_ci:jenkins'],
 } ->


### PR DESCRIPTION
Allow jenkins jobs to publish stats.